### PR TITLE
pip install submodule to avoid install all dependecies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Cause: @ on tensor operand W w/shape [764, 100] and operand X.T w/shape [764, 20
 ## Install
 
 ```
-pip install tensor-sensor
+pip install tensor-sensor # This will only install the library for you
+pip install tensor-sensor[torch] # install pytorch related depedency
+pip install tensor-sensor[tensorflow] # install tensorflow related depedency
+pip install tensor-sensor[all] # install both tensorflow and pytorch
 ```
 
 which gives you module `tsensor`. I developed and tested with the following versions

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup
 
 tensorflow_requires = ['tensorflow']
 torch_requires = ['torch']
-all_requires = tensorflow_requires + pytorch_requires
+all_requires = tensorflow_requires + torch_requires
 
 exec(open('tsensor/version.py').read())
 setup(
@@ -39,9 +39,9 @@ setup(
     python_requires='>=3.6',
     install_requires=['graphviz>=0.14.1','numpy','IPython', 'matplotlib'],
     extra_requires = {'all': all_requires,
-                      'torch' torch_requires,
+                      'torch': torch_requires,
                       'tensorflow': tensorflow_requires
-                     }
+                     },
     description='The goal of this library is to generate more helpful exception messages for numpy/pytorch tensor algebra expressions.',
 #    keywords='visualization data structures',
     classifiers=['License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     author_email='parrt@cs.usfca.edu',
     python_requires='>=3.6',
     install_requires=['graphviz>=0.14.1','numpy','IPython', 'matplotlib'],
-    extra_requires = {'all': all_requires,
+    extras_require = {'all': all_requires,
                       'torch': torch_requires,
                       'tensorflow': tensorflow_requires
                      },

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,10 @@ SOFTWARE.
 """
 from setuptools import setup
 
+tensorflow_requires = ['tensorflow']
+torch_requires = ['torch']
+all_requires = tensorflow_requires + pytorch_requires
+
 exec(open('tsensor/version.py').read())
 setup(
     name='tensor-sensor',
@@ -33,7 +37,11 @@ setup(
     author='Terence Parr',
     author_email='parrt@cs.usfca.edu',
     python_requires='>=3.6',
-    install_requires=['graphviz>=0.14.1','numpy','torch','tensorflow', 'IPython', 'matplotlib'],
+    install_requires=['graphviz>=0.14.1','numpy','IPython', 'matplotlib'],
+    extra_requires = {'all': all_requires,
+                      'torch' torch_requires,
+                      'tensorflow': tensorflow_requires
+                     }
     description='The goal of this library is to generate more helpful exception messages for numpy/pytorch tensor algebra expressions.',
 #    keywords='visualization data structures',
     classifiers=['License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Very often, people already have the tensor library they are using, keras, torch, tensorflow if they are coming for this library. Currently, the package tries to install all dependencies. For example, if I am using PyTorch, I don't really need to install the big TensorFlow library in the environment.

Added options
```
 pip install tensor-sensor[all]
 pip install tensor-sensor[torch]
 pip install tensor-sensor[tensorflow]
```